### PR TITLE
A readable stream should emit end when it ends

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function MuxDemux (opts) {
         throw new Error('stream is not writable')
       md.emit('data', [s.id, 'data', data])
     }, function () {
-      if (this.readable && !opts.allowHalfOpen) {
+      if (this.readable && !opts.allowHalfOpen && !this.ended) {
         this.emit("end")
       }
       md.emit('data', [s.id, 'end'])


### PR DESCRIPTION
The main purpose for this is so that pipe gets the end event of the readable stream
and can clean up the event listeners otherwise memory leak hell

The problem is that it breaks test/index.js and I dont know why.
Better yet I don't understand your test. You will have to fix this. Sorry!
