### PR TITLE
emit error on outer

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function MuxDemux (opts) {
     var s = streams[id]
     if(!s) {
       if(event != 'new')
-        return md.emit('error', new Error('does not have stream:' + id))
+        return outer.emit('error', new Error('does not have stream:' + id))
       md.emit('connection', createStream(id, data[1].meta, data[1].opts))
     } 
     else if (event === 'pause')


### PR DESCRIPTION
This allows the user to attach an error handler to the outer stream and intercept this error

Otherwise by default it will crash the server
