### PR TITLE
Allow extra close event to come through

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ function MuxDemux (opts) {
     var event = data[0]
     var s = streams[id]
     if(!s) {
+      if(event == 'close')
+        return
       if(event != 'new')
         return outer.emit('error', new Error('does not have stream:' + id))
       md.emit('connection', createStream(id, data[1].meta, data[1].opts))


### PR DESCRIPTION
Scenario:

Server has the stream closed already but because the browser was 
disconnected due to flaky connection and buffered up it's close command the
server get's a close command from the client after it's closed that stream.

I think this is a race condition.

Playing with taking [the service example up and down with multiple browsers]( https://github.com/Raynos/seaport-proxy/tree/master/examples/service) reproduces this issue.
