### PR TITLE
Emit error instead of throwing

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function MuxDemux (opts) {
   function createStream(id, meta, opts) {
     var s = es.through(function (data) {
       if(!this.writable)
-        throw new Error('stream is not writable')
+        return outer.emit("error", Error('stream is not writable: ' + id))
       md.emit('data', [s.id, 'data', data])
     }, function () {
       md.emit('data', [s.id, 'end'])


### PR DESCRIPTION
This allows me to catch the error more gracefully and close that server <-> client connection.

This will force to browser to open a fresh connection which doesn't have streams in corrupted state.
