### PR TITLE
Expose a destroyed flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ function MuxDemux (opts) {
     var err = _err || new Error ('unexpected disconnection')
     for (var i in streams) {
       var s = streams[i]
+      s.destroyed = true
       if (opts && opts.error === false) {
         s.end()
       } else {


### PR DESCRIPTION
This allows me to distinguish between a 

 - mdm stream ended because the remote ended it
 - mdm stream ended because md was ended (i.e. a server disconnect)
