### PR TITLE
object based error messages

### DIFF
--- a/examples/error.js
+++ b/examples/error.js
@@ -6,7 +6,7 @@ net.createServer(function (con) {
   var mdm2 = MuxDemux()
   mdm2.on('connection', function (stream) {
     stream.on('error', function (error) {
-      console.log(error.message)
+      console.log(error)
     })
   })
   con.pipe(mdm2).pipe(con)
@@ -19,7 +19,9 @@ net.createServer(function (con) {
   var es = mdm1.createWriteStream('errors')
 
   setInterval(function () {
-    es.error("error message as string")
+    es.error({
+        "any error": "message"
+    })
   }, 1e3)
 
 })

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function MuxDemux (opts) {
       if(p) s.emit('drain')
     }
     else if (event === 'error')
-      s.emit('error', new Error(data[1]))
+      s.emit('error', data[1])
     else {
       s.emit.apply(s, data)
     }


### PR DESCRIPTION
Using `new Error(str)` forces you to encode error messages in a string. This is a pain in the ass.

So let's just send error data directly!
