### PR TITLE
package.json has invalid version number for event-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "assertions": "2.3",
     "tap": "~0.3.0",
-    "event-stream": "~0.3.7"
+    "event-stream": "~3.0.7"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (dominictarr.com)",
   "optionalDependencies": {},


### PR DESCRIPTION
I was checking out this module per @substack's suggestion (https://twitter.com/substack/status/269682156966658048), and `npm install` failed hard. Looks like a typo involving the version number for event-stream.

I did generic npm installs on the other dependencies, and all the tests passed, but didn't want to update more than required.

Thanks for writing a module that is taking a very long time for me to understand :)
