### PR TITLE
respect pause and resume

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "xtend": "~1.0.3",
     "stream-serializer": "~0.0.3",
-    "through": "~1.1.0"
+    "through": "~1.1.0",
+    "duplex": "~1.0.0"
   },
   "scripts": {
     "test": "tap test/*.js"

--- a/test/pause.js
+++ b/test/pause.js
@@ -1,0 +1,21 @@
+var MuxDemux = require("..")
+var assert = require("assert")
+
+var mdm1 = MuxDemux()
+var mdm2 = MuxDemux()
+var called = false
+
+mdm2.on("connection", function (stream) {
+    assert.equal(stream.meta, "foo")
+    called = true
+})
+
+mdm1.pause()
+
+mdm1.createStream("foo")
+
+mdm1.pipe(mdm2).pipe(mdm1)
+
+mdm1.resume()
+
+assert.equal(called, true)


### PR DESCRIPTION
Note I call

`var md = duplex().resume()`

Because a bunch of your tests assume that `md` is in a resumed state initially.

It's upto you whether you want to change `md` to be paused and resume on next tick.
