### PR TITLE
update json-buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "duplex": "~1.0.0",
     "stream-combiner": "0.0.2",
     "msgpack-stream": "~0.0.3",
-    "json-buffer": "~2.0.1"
+    "json-buffer": "~2.0.4"
   },
   "scripts": {
     "test": "set -e; for t in test/*.js; do node $t; done"


### PR DESCRIPTION
dunno why, but

``` bash
$ npm install mux-demux
mux-demux@3.7.5 node_modules/mux-demux
├── stream-serializer@1.1.1
├── xtend@1.0.3
├── duplex@1.0.0
├── through@2.3.4
├── stream-combiner@0.0.2 (duplexer@0.0.4)
├── msgpack-stream@0.0.5 (msgpack-browserify@0.0.0, bops@0.0.6)
└── json-buffer@2.0.3 (bops@0.0.6)
```

doesn't give me the latest json-buffer
